### PR TITLE
Upgrade to v1.1.2

### DIFF
--- a/appchain-anchor/Cargo.toml
+++ b/appchain-anchor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "appchain-anchor"
-version = "1.1.1"
+version = "1.1.2"
 authors = ["Octopus Network"]
 edition = "2018"
 

--- a/appchain-anchor/src/assets/near_fungible_tokens.rs
+++ b/appchain-anchor/src/assets/near_fungible_tokens.rs
@@ -252,21 +252,29 @@ impl AppchainAnchor {
                         receiver_id_in_appchain: receiver_id_in_appchain.clone(),
                         amount,
                     });
-                    self.internal_append_appchain_notification(
+                    let appchain_notification_history = self.internal_append_appchain_notification(
                         AppchainNotification::NearFungibleTokenLocked {
-                            contract_account: near_fungible_token.contract_account,
+                            contract_account: near_fungible_token.contract_account.clone(),
                             sender_id_in_near: sender_id.clone(),
                             receiver_id_in_appchain: receiver_id_in_appchain.clone(),
                             amount,
                         },
+                    );
+                    log!(
+                        "Received fungible token in contract '{}' from '{}'. Start transfer to '{}' of appchain. Amount: '{}', Crosschain notification index: '{}'.",
+                        &near_fungible_token.contract_account,
+                        &sender_id.clone(),
+                        &receiver_id_in_appchain,
+                        &amount.0,
+                        &appchain_notification_history.index.0
                     );
                     return PromiseOrValue::Value(0.into());
                 }
             }
         }
         panic!(
-            "Invalid deposit '{}' of unknown NEP-141 asset from '{}' received. Return deposit.",
-            amount.0, sender_id,
+            "Received invalid deposit '{}' in contract '{}' from '{}'. Return deposit.",
+            &amount.0, &predecessor_account_id, &sender_id,
         );
     }
     //

--- a/appchain-anchor/src/assets/wrapped_appchain_token.rs
+++ b/appchain-anchor/src/assets/wrapped_appchain_token.rs
@@ -39,6 +39,7 @@ impl Default for WrappedAppchainToken {
             premined_balance: U128::from(0),
             changed_balance: I128::from(0),
             price_in_usd: U128::from(0),
+            total_supply: U128::from(0),
         }
     }
 }
@@ -76,6 +77,7 @@ impl WrappedAppchainTokenManager for AppchainAnchor {
         wrapped_appchain_token.metadata = metadata;
         wrapped_appchain_token.premined_beneficiary = premined_beneficiary;
         wrapped_appchain_token.premined_balance = premined_balance;
+        wrapped_appchain_token.total_supply = premined_balance;
         self.wrapped_appchain_token.set(&wrapped_appchain_token);
     }
     //
@@ -83,6 +85,13 @@ impl WrappedAppchainTokenManager for AppchainAnchor {
         self.assert_owner();
         let mut wrapped_appchain_token = self.wrapped_appchain_token.get().unwrap();
         wrapped_appchain_token.contract_account = contract_account;
+        self.wrapped_appchain_token.set(&wrapped_appchain_token);
+    }
+    //
+    fn set_total_supply_of_wrapped_appchain_token(&mut self, total_supply: U128) {
+        self.assert_owner();
+        let mut wrapped_appchain_token = self.wrapped_appchain_token.get().unwrap();
+        wrapped_appchain_token.total_supply = total_supply;
         self.wrapped_appchain_token.set(&wrapped_appchain_token);
     }
     //
@@ -132,7 +141,6 @@ impl AppchainAnchor {
         appchain_message_nonce: u32,
     ) -> AppchainMessageProcessingResult {
         let wrapped_appchain_token = self.wrapped_appchain_token.get().unwrap();
-        let protocol_settings = self.protocol_settings.get().unwrap();
         if let Some(sender_id) = &sender_id {
             if !AccountIdInAppchain::new(Some(sender_id.clone())).is_valid() {
                 let result = AppchainMessageProcessingResult::Error {
@@ -143,52 +151,28 @@ impl AppchainAnchor {
                 return result;
             }
         }
-        if wrapped_appchain_token.total_market_value()
-            + wrapped_appchain_token.get_market_value_of(amount.0)
-            > self.get_market_value_of_staked_oct_token().0
-                * u128::from(
-                    protocol_settings.maximum_market_value_percent_of_wrapped_appchain_token,
-                )
-                / 100
-        {
-            let message = format!("Too much wrapped appchain token to mint.");
-            self.internal_append_anchor_event(AnchorEvent::FailedToMintWrappedAppchainToken {
-                sender_id_in_appchain: sender_id,
-                receiver_id_in_near: receiver_id,
-                amount,
-                appchain_message_nonce,
-                reason: message.clone(),
-            });
-            let result = AppchainMessageProcessingResult::Error {
-                nonce: appchain_message_nonce,
-                message,
-            };
-            self.record_appchain_message_processing_result(&result);
-            result
-        } else {
-            ext_fungible_token::mint(
-                receiver_id.clone(),
-                amount,
-                &wrapped_appchain_token.contract_account,
-                STORAGE_DEPOSIT_FOR_NEP141_TOEKN,
-                GAS_FOR_MINT_FUNGIBLE_TOKEN,
-            )
-            .then(ext_self::resolve_wrapped_appchain_token_minting(
-                sender_id.clone(),
-                receiver_id.clone(),
-                amount,
-                appchain_message_nonce,
-                &env::current_account_id(),
-                0,
-                GAS_FOR_RESOLVER_FUNCTION,
-            ));
-            AppchainMessageProcessingResult::Ok {
-                nonce: appchain_message_nonce,
-                message: Some(format!(
-                    "Need to confirm result of 'mint' on account '{}'.",
-                    wrapped_appchain_token.contract_account
-                )),
-            }
+        ext_fungible_token::mint(
+            receiver_id.clone(),
+            amount,
+            &wrapped_appchain_token.contract_account,
+            STORAGE_DEPOSIT_FOR_NEP141_TOEKN,
+            GAS_FOR_MINT_FUNGIBLE_TOKEN,
+        )
+        .then(ext_self::resolve_wrapped_appchain_token_minting(
+            sender_id.clone(),
+            receiver_id.clone(),
+            amount,
+            appchain_message_nonce,
+            &env::current_account_id(),
+            0,
+            GAS_FOR_RESOLVER_FUNCTION,
+        ));
+        AppchainMessageProcessingResult::Ok {
+            nonce: appchain_message_nonce,
+            message: Some(format!(
+                "Need to confirm result of 'mint' on account '{}'.",
+                wrapped_appchain_token.contract_account
+            )),
         }
     }
 }

--- a/appchain-anchor/src/assets/wrapped_appchain_token.rs
+++ b/appchain-anchor/src/assets/wrapped_appchain_token.rs
@@ -203,10 +203,10 @@ impl WrappedAppchainTokenContractResolver for AppchainAnchor {
         amount: U128,
     ) {
         assert_self();
+        let mut wrapped_appchain_token = self.wrapped_appchain_token.get().unwrap();
         match env::promise_result(0) {
             PromiseResult::NotReady => unreachable!(),
             PromiseResult::Successful(_) => {
-                let mut wrapped_appchain_token = self.wrapped_appchain_token.get().unwrap();
                 wrapped_appchain_token.changed_balance = I128::from(
                     wrapped_appchain_token.changed_balance.0 - i128::try_from(amount.0).unwrap(),
                 );
@@ -223,21 +223,22 @@ impl WrappedAppchainTokenContractResolver for AppchainAnchor {
                         amount: U128::from(amount),
                     },
                 );
-                env::log(
-                    format!(
-                        "Wrapped appchain token burnt by '{}' for '{}' of appchain. Amount: '{}', Crosschain notification index: '{}'.",
-                        &sender_id_in_near, &receiver_id_in_appchain, &amount.0, &appchain_notification_history.index.0
-                    )
-                    .as_bytes(),
+                log!(
+                    "Wrapped appchain token burnt in contract '{}' by '{}' for '{}' of appchain. Amount: '{}', Crosschain notification index: '{}'.",
+                    &wrapped_appchain_token.contract_account,
+                    &sender_id_in_near,
+                    &receiver_id_in_appchain,
+                    &amount.0,
+                    &appchain_notification_history.index.0
                 );
             }
             PromiseResult::Failed => {
-                env::log(
-                    format!(
-                        "Failed to burn wrapped appchain token owned by '{}' for '{}' in appchain. Amount: '{}'",
-                        &sender_id_in_near, &receiver_id_in_appchain, &amount.0
-                    )
-                    .as_bytes(),
+                log!(
+                    "Failed to burn wrapped appchain token in contract '{}' by '{}' for '{}' in appchain. Amount: '{}'",
+                    &wrapped_appchain_token.contract_account,
+                    &sender_id_in_near,
+                    &receiver_id_in_appchain,
+                    &amount.0
                 );
                 self.internal_append_anchor_event(AnchorEvent::FailedToBurnWrappedAppchainToken {
                     sender_id_in_near: sender_id_in_near.clone(),

--- a/appchain-anchor/src/interfaces.rs
+++ b/appchain-anchor/src/interfaces.rs
@@ -377,6 +377,8 @@ pub trait WrappedAppchainTokenManager {
     ///
     fn set_account_of_wrapped_appchain_token(&mut self, contract_account: AccountId);
     ///
+    fn set_total_supply_of_wrapped_appchain_token(&mut self, total_supply: U128);
+    ///
     fn set_price_of_wrapped_appchain_token(&mut self, price: U128);
     ///
     fn burn_wrapped_appchain_token(&self, receiver_id: String, amount: U128);

--- a/appchain-anchor/src/storage_migration.rs
+++ b/appchain-anchor/src/storage_migration.rs
@@ -1,60 +1,20 @@
-use crate::validator_set::ValidatorSet;
 use crate::*;
 
+use near_contract_standards::fungible_token::metadata::FungibleTokenMetadata;
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 use near_sdk::collections::{LazyOption, LookupMap};
+use near_sdk::json_types::I128;
 use near_sdk::{env, near_bindgen, AccountId, Balance};
 
-#[derive(BorshDeserialize, BorshSerialize)]
-pub struct IndexedHistories<T: BorshDeserialize + BorshSerialize + IndexedAndClearable> {
-    /// The anchor event data map.
-    pub histories: LookupMap<u64, T>,
-    /// The start index of valid anchor event.
-    pub start_index: u64,
-    /// The end index of valid anchor event.
-    pub end_index: u64,
-}
-
-#[derive(BorshDeserialize, BorshSerialize)]
-pub struct OldProtocolSettings {
-    /// A validator has to deposit a certain amount of OCT token to this contract for
-    /// being validator of the appchain.
-    pub minimum_validator_deposit: U128,
-    /// The minimum deposit amount for a delegator to delegate his voting weight to
-    /// a certain validator.
-    pub minimum_delegator_deposit: U128,
-    /// The minimum price (in USD) of total stake in this contract for
-    /// booting corresponding appchain
-    pub minimum_total_stake_price_for_booting: U128,
-    /// The maximum percentage of the total market value of all NEP-141 tokens to the total
-    /// market value of OCT token staked in this contract
-    pub maximum_market_value_percent_of_near_fungible_tokens: u16,
-    /// The maximum percentage of the total market value of wrapped appchain token to the total
-    /// market value of OCT token staked in this contract
-    pub maximum_market_value_percent_of_wrapped_appchain_token: u16,
-    /// The minimum number of validator(s) registered in this contract for
-    /// booting the corresponding appchain and keep it alive.
-    pub minimum_validator_count: U64,
-    /// The maximum number of validator(s) registered in this contract for
-    /// the corresponding appchain.
-    pub maximum_validator_count: U64,
-    /// The maximum number of validator(s) which a delegator can delegate to.
-    pub maximum_validators_per_delegator: U64,
-    /// The unlock period (in days) for validator(s) can withdraw their deposit after
-    /// they are removed from the corresponding appchain.
-    pub unlock_period_of_validator_deposit: U64,
-    /// The unlock period (in days) for delegator(s) can withdraw their deposit after
-    /// they no longer delegates their stake to a certain validator on the corresponding appchain.
-    pub unlock_period_of_delegator_deposit: U64,
-    /// The maximum number of historical eras that the validators or delegators are allowed to
-    /// withdraw their reward
-    pub maximum_era_count_of_unwithdrawn_reward: U64,
-    /// The maximum number of valid appchain message.
-    /// If the era number of appchain message is smaller than the latest era number minus
-    /// this value, the message will be considered as `invalid`.
-    pub maximum_era_count_of_valid_appchain_message: U64,
-    /// The percent of commission fees of a validator's reward in an era
-    pub validator_commission_percent: u16,
+#[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Clone)]
+#[serde(crate = "near_sdk::serde")]
+pub struct OldWrappedAppchainToken {
+    pub metadata: FungibleTokenMetadata,
+    pub contract_account: AccountId,
+    pub premined_beneficiary: AccountId,
+    pub premined_balance: U128,
+    pub changed_balance: I128,
+    pub price_in_usd: U128,
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
@@ -68,14 +28,14 @@ pub struct OldAppchainAnchor {
     /// The info of OCT token.
     oct_token: LazyOption<OctToken>,
     /// The info of wrapped appchain token in NEAR protocol.
-    wrapped_appchain_token: LazyOption<WrappedAppchainToken>,
+    wrapped_appchain_token: LazyOption<OldWrappedAppchainToken>,
     /// The NEP-141 tokens data.
     near_fungible_tokens: LazyOption<NearFungibleTokens>,
     /// The history data of validator set.
-    validator_set_histories: LazyOption<IndexedHistories<ValidatorSetOfEra>>,
+    validator_set_histories: LazyOption<LookupArray<ValidatorSetOfEra>>,
     /// The validator set of the next era in appchain.
     /// This validator set is only for checking staking rules.
-    next_validator_set: LazyOption<ValidatorSet>,
+    next_validator_set: LazyOption<NextValidatorSet>,
     /// The map of unwithdrawn validator rewards in eras, in unit of wrapped appchain token.
     /// The key in map is `(era_number, account_id_of_validator)`
     unwithdrawn_validator_rewards: LookupMap<(u64, AccountId), Balance>,
@@ -91,15 +51,15 @@ pub struct OldAppchainAnchor {
     /// The anchor settings for appchain.
     anchor_settings: LazyOption<AnchorSettings>,
     /// The protocol settings for appchain anchor.
-    protocol_settings: LazyOption<OldProtocolSettings>,
+    protocol_settings: LazyOption<ProtocolSettings>,
     /// The state of the corresponding appchain.
     appchain_state: AppchainState,
     /// The staking history data happened in this contract.
-    staking_histories: LazyOption<IndexedHistories<StakingHistory>>,
+    staking_histories: LazyOption<LookupArray<StakingHistory>>,
     /// The anchor event history data.
-    anchor_event_histories: LazyOption<IndexedHistories<AnchorEventHistory>>,
+    anchor_event_histories: LazyOption<LookupArray<AnchorEventHistory>>,
     /// The appchain notification history data.
-    appchain_notification_histories: LazyOption<IndexedHistories<AppchainNotificationHistory>>,
+    appchain_notification_histories: LazyOption<LookupArray<AppchainNotificationHistory>>,
     /// The status of permissionless actions.
     permissionless_actions_status: LazyOption<PermissionlessActionsStatus>,
     /// The state of beefy light client
@@ -112,12 +72,14 @@ pub struct OldAppchainAnchor {
     user_staking_histories: LazyOption<UserStakingHistories>,
     /// Whether the rewards withdrawal is paused
     rewards_withdrawal_is_paused: bool,
+    /// The processing result of appchain messages
+    appchain_message_processing_results: LazyOption<AppchainMessageProcessingResults>,
 }
 
 #[near_bindgen]
 impl AppchainAnchor {
     #[init(ignore_state)]
-    pub fn migrate_state() -> Self {
+    pub fn migrate_state(total_supply: U128) -> Self {
         // Deserialize the state using the old contract structure.
         let old_contract: OldAppchainAnchor = env::state_read().expect("Old state doesn't exist");
         // Verify that the migration can only be done by the owner.
@@ -128,67 +90,41 @@ impl AppchainAnchor {
             "Can only be called by the owner"
         );
         //
-        let old_next_validator_set = old_contract.next_validator_set.get().unwrap();
-        let old_protocol_settings = old_contract.protocol_settings.get().unwrap();
+        let old_wrapped_appchain_token = old_contract.wrapped_appchain_token.get().unwrap();
         // Create the new contract using the data from the old contract.
         let new_contract = AppchainAnchor {
             appchain_id: old_contract.appchain_id,
             appchain_registry: old_contract.appchain_registry,
             owner: old_contract.owner,
             oct_token: old_contract.oct_token,
-            wrapped_appchain_token: old_contract.wrapped_appchain_token,
+            wrapped_appchain_token: LazyOption::new(
+                StorageKey::WrappedAppchainToken.into_bytes(),
+                Some(&WrappedAppchainToken::from_old_version(
+                    old_wrapped_appchain_token,
+                    total_supply,
+                )),
+            ),
             near_fungible_tokens: old_contract.near_fungible_tokens,
-            validator_set_histories: LazyOption::new(
-                StorageKey::ValidatorSetHistories.into_bytes(),
-                Some(&LookupArray::from_indexed_histories(
-                    old_contract.validator_set_histories.get().unwrap(),
-                )),
-            ),
-            next_validator_set: LazyOption::new(
-                StorageKey::NextValidatorSet.into_bytes(),
-                Some(&NextValidatorSet::from_validator_set(
-                    old_next_validator_set,
-                )),
-            ),
+            validator_set_histories: old_contract.validator_set_histories,
+            next_validator_set: old_contract.next_validator_set,
             unwithdrawn_validator_rewards: old_contract.unwithdrawn_validator_rewards,
             unwithdrawn_delegator_rewards: old_contract.unwithdrawn_delegator_rewards,
             unbonded_stakes: old_contract.unbonded_stakes,
             validator_profiles: old_contract.validator_profiles,
             appchain_settings: old_contract.appchain_settings,
             anchor_settings: old_contract.anchor_settings,
-            protocol_settings: LazyOption::new(
-                StorageKey::ProtocolSettings.into_bytes(),
-                Some(&ProtocolSettings::from_old_version(old_protocol_settings)),
-            ),
+            protocol_settings: old_contract.protocol_settings,
             appchain_state: old_contract.appchain_state,
-            staking_histories: LazyOption::new(
-                StorageKey::StakingHistories.into_bytes(),
-                Some(&LookupArray::from_indexed_histories(
-                    old_contract.staking_histories.get().unwrap(),
-                )),
-            ),
-            anchor_event_histories: LazyOption::new(
-                StorageKey::AnchorEventHistories.into_bytes(),
-                Some(&LookupArray::from_indexed_histories(
-                    old_contract.anchor_event_histories.get().unwrap(),
-                )),
-            ),
-            appchain_notification_histories: LazyOption::new(
-                StorageKey::AppchainNotificationHistories.into_bytes(),
-                Some(&LookupArray::from_indexed_histories(
-                    old_contract.appchain_notification_histories.get().unwrap(),
-                )),
-            ),
+            staking_histories: old_contract.staking_histories,
+            anchor_event_histories: old_contract.anchor_event_histories,
+            appchain_notification_histories: old_contract.appchain_notification_histories,
             permissionless_actions_status: old_contract.permissionless_actions_status,
             beefy_light_client_state: old_contract.beefy_light_client_state,
             reward_distribution_records: old_contract.reward_distribution_records,
             asset_transfer_is_paused: old_contract.asset_transfer_is_paused,
             user_staking_histories: old_contract.user_staking_histories,
             rewards_withdrawal_is_paused: old_contract.rewards_withdrawal_is_paused,
-            appchain_message_processing_results: LazyOption::new(
-                StorageKey::AppchainMessageProcessingResults.into_bytes(),
-                Some(&AppchainMessageProcessingResults::new()),
-            ),
+            appchain_message_processing_results: old_contract.appchain_message_processing_results,
         };
         //
         //
@@ -196,44 +132,17 @@ impl AppchainAnchor {
     }
 }
 
-impl ProtocolSettings {
-    pub fn from_old_version(old_version: OldProtocolSettings) -> ProtocolSettings {
-        ProtocolSettings {
-            minimum_validator_deposit: old_version.minimum_validator_deposit,
-            minimum_validator_deposit_changing_amount: U128::from(1000 * OCT_DECIMALS_VALUE),
-            maximum_validator_stake_percent: 25,
-            minimum_delegator_deposit: old_version.minimum_delegator_deposit,
-            minimum_delegator_deposit_changing_amount: U128::from(100 * OCT_DECIMALS_VALUE),
-            minimum_total_stake_price_for_booting: old_version
-                .minimum_total_stake_price_for_booting,
-            maximum_market_value_percent_of_near_fungible_tokens: old_version
-                .maximum_market_value_percent_of_near_fungible_tokens,
-            maximum_market_value_percent_of_wrapped_appchain_token: old_version
-                .maximum_market_value_percent_of_wrapped_appchain_token,
-            minimum_validator_count: old_version.minimum_validator_count,
-            maximum_validator_count: old_version.maximum_validator_count,
-            maximum_validators_per_delegator: old_version.maximum_validators_per_delegator,
-            unlock_period_of_validator_deposit: old_version.unlock_period_of_validator_deposit,
-            unlock_period_of_delegator_deposit: old_version.unlock_period_of_delegator_deposit,
-            maximum_era_count_of_unwithdrawn_reward: old_version
-                .maximum_era_count_of_unwithdrawn_reward,
-            maximum_era_count_of_valid_appchain_message: old_version
-                .maximum_era_count_of_valid_appchain_message,
-            validator_commission_percent: old_version.validator_commission_percent,
-            maximum_allowed_unprofitable_era_count: 3,
-        }
-    }
-}
-
-impl<T> LookupArray<T>
-where
-    T: BorshDeserialize + BorshSerialize + IndexedAndClearable,
-{
-    pub fn from_indexed_histories(indexed_histories: IndexedHistories<T>) -> Self {
+impl WrappedAppchainToken {
+    ///
+    pub fn from_old_version(old_version: OldWrappedAppchainToken, total_supply: U128) -> Self {
         Self {
-            lookup_map: indexed_histories.histories,
-            start_index: indexed_histories.start_index,
-            end_index: indexed_histories.end_index,
+            metadata: old_version.metadata,
+            contract_account: old_version.contract_account,
+            premined_beneficiary: old_version.premined_beneficiary,
+            premined_balance: old_version.premined_balance,
+            changed_balance: old_version.changed_balance,
+            price_in_usd: old_version.price_in_usd,
+            total_supply,
         }
     }
 }

--- a/appchain-anchor/src/types.rs
+++ b/appchain-anchor/src/types.rs
@@ -171,6 +171,7 @@ pub struct WrappedAppchainToken {
     pub premined_balance: U128,
     pub changed_balance: I128,
     pub price_in_usd: U128,
+    pub total_supply: U128,
 }
 
 /// The bridging state of NEP-141 token.

--- a/appchain-anchor/tests/test_anchor_actions.rs
+++ b/appchain-anchor/tests/test_anchor_actions.rs
@@ -32,16 +32,9 @@ const TOTAL_SUPPLY: u128 = 100_000_000;
 
 #[test]
 fn test_anchor_actions() {
-    let (root, oct_token, wrapped_appchain_token, registry, anchor, users) =
+    let (root, oct_token, wrapped_appchain_token, _registry, anchor, users) =
         test_normal_actions(false, true);
-    test_staking_actions(
-        &root,
-        &oct_token,
-        &wrapped_appchain_token,
-        &registry,
-        &anchor,
-        &users,
-    );
+    test_staking_actions(&root, &oct_token, &wrapped_appchain_token, &anchor, &users);
     //
     // Reset contract status
     //
@@ -74,6 +67,7 @@ fn test_anchor_actions() {
     let result = sudo_actions::reset_validator_set_histories_to(&root, &anchor, U64::from(0));
     result.assert_success();
     common::print_anchor_status(&anchor);
+    common::print_wrapped_appchain_token_info(&anchor);
     common::print_validator_list_of(&anchor, Some(0));
     common::print_validator_list_of(&anchor, Some(1));
     common::print_validator_list_of(&anchor, Some(2));
@@ -533,14 +527,11 @@ fn test_staking_actions(
     root: &UserAccount,
     oct_token: &ContractAccount<MockOctTokenContract>,
     wrapped_appchain_token: &ContractAccount<WrappedAppchainTokenContract>,
-    registry: &ContractAccount<MockAppchainRegistryContract>,
     anchor: &ContractAccount<AppchainAnchorContract>,
     users: &Vec<UserAccount>,
 ) {
     let user0_id_in_appchain =
         "0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d".to_string();
-    let user1_id_in_appchain =
-        "d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da270".to_string();
     let user4_id_in_appchain =
         "d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da273".to_string();
     let mut user0_profile = HashMap::<String, String>::new();
@@ -784,6 +775,7 @@ fn test_staking_actions(
     // Print whole status
     //
     common::print_anchor_status(&anchor);
+    common::print_wrapped_appchain_token_info(&anchor);
     common::print_validator_list_of(&anchor, Some(0));
     common::print_validator_list_of(&anchor, Some(1));
     common::print_validator_list_of(&anchor, Some(2));
@@ -829,7 +821,7 @@ fn distribute_reward_of(
     loop {
         let result = permissionless_actions::try_complete_distributing_reward(root, anchor);
         println!(
-            "Try complete switching era: {}",
+            "Try complete distributing reward: {}",
             serde_json::to_string::<MultiTxsOperationProcessingResult>(&result).unwrap()
         );
         let processing_status =
@@ -939,15 +931,19 @@ fn test_migration() {
     let user1_id_in_appchain =
         "d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da270".to_string();
     //
-    let (root, _oct_token, _wrapped_appchain_token, _registryy, anchor, users) =
+    let (root, _oct_token, _wrapped_appchain_token, _registry, anchor, users) =
         test_normal_actions(true, false);
     common::deploy_new_anchor_contract(&anchor);
-    let result = call!(root, anchor.migrate_state());
+    let result = call!(
+        root,
+        anchor.migrate_state(U128::from(common::to_oct_amount(TOTAL_SUPPLY / 2)))
+    );
     common::print_execution_result("migrate_state", &result);
     //
     //
     //
     common::print_anchor_status(&anchor);
+    common::print_wrapped_appchain_token_info(&anchor);
     common::print_validator_set_info_of(&anchor, U64::from(0));
     common::print_validator_set_info_of(&anchor, U64::from(1));
     common::print_validator_list_of(&anchor, Some(0));


### PR DESCRIPTION
## All Changes

* Change log messages for cross chain asset transfer.
* Add field `total_supply` to struct `WrappedAppchainToken`.
* Change checking condition for cross chain message `AppchainEvent::NativeTokenLocked`. Now the transfer of wrapped appchain token from appchain to NEAR is limited by the `total_supply` of wrapped appchain token, rather than the market value.
* Add function `set_total_supply_of_wrapped_appchain_token` for the owner to change the `total_supply` of wrapped appchain token on demand.
