### PR TITLE
Upgrade to v2.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ checksum = "98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602"
 
 [[package]]
 name = "appchain-anchor"
-version = "2.3.1"
+version = "2.4.0"
 dependencies = [
  "beefy-light-client",
  "ed25519-dalek",
@@ -118,12 +118,13 @@ dependencies = [
 
 [[package]]
 name = "appchain-anchor-wrapper"
-version = "2.3.1"
+version = "2.4.0"
 dependencies = [
  "anyhow",
  "appchain-anchor",
  "beefy-light-client",
  "beefy-merkle-tree 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.12)",
+ "council-keeper",
  "hex 0.4.3",
  "hex-literal",
  "mock-appchain-registry",
@@ -133,7 +134,6 @@ dependencies = [
  "near-sdk",
  "near-units",
  "num-format",
- "octopus-council",
  "parity-scale-codec 2.3.1",
  "parity-scale-codec 3.2.1",
  "secp256k1",
@@ -642,6 +642,15 @@ name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
+name = "council-keeper"
+version = "0.5.1"
+source = "git+https://github.com/octopus-network/octopus-dao?branch=main#1f391891f47cf9b0c59d25a6700a13c2982c2880"
+dependencies = [
+ "near-contract-standards",
+ "near-sdk",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -2175,15 +2184,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "octopus-council"
-version = "0.3.0"
-source = "git+https://github.com/octopus-network/octopus-dao?branch=main#71bb8551d95c5af2ea9ddcff39693d7999ab0e76"
-dependencies = [
- "near-contract-standards",
- "near-sdk",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "appchain-anchor-wrapper"
-version = "2.3.1"
+version = "2.4.0"
 authors = ["Octopus Network"]
 edition = "2021"
 
@@ -24,7 +24,7 @@ mock-appchain-registry = { path = "./mock-appchain-registry" }
 mock-oct-token = { path = "./mock-oct-token" }
 wrapped-appchain-token = { git = "https://github.com/octopus-network/wrapped-appchain-token.git", branch = "v2.0.0" }
 wrapped-appchain-nft = { git = "https://github.com/octopus-network/wrapped-appchain-nft.git", branch = "main" }
-octopus-council = { git = "https://github.com/octopus-network/octopus-dao", branch = "main" }
+council-keeper = { git = "https://github.com/octopus-network/octopus-dao", branch = "main" }
 tokio = { version = "1.14", features = ["full"] }
 workspaces = "0.4"
 

--- a/appchain-anchor/Cargo.toml
+++ b/appchain-anchor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "appchain-anchor"
-version = "2.3.1"
+version = "2.4.0"
 authors = ["Octopus Network"]
 edition = "2021"
 

--- a/appchain-anchor/src/interfaces.rs
+++ b/appchain-anchor/src/interfaces.rs
@@ -276,6 +276,8 @@ pub trait ProtocolSettingsManager {
     fn change_validator_commission_percent(&mut self, value: u16);
     ///
     fn change_maximum_allowed_unprofitable_era_count(&mut self, value: u16);
+    ///
+    fn change_subaccount_for_council_keeper_contract(&mut self, subaccount_name: String);
 }
 
 pub trait AppchainSettingsManager {

--- a/appchain-anchor/src/interfaces.rs
+++ b/appchain-anchor/src/interfaces.rs
@@ -159,8 +159,8 @@ pub trait AnchorViewer {
 }
 
 pub trait AppchainLifecycleManager {
-    /// Verify and change the state of corresponding appchain to `booting`.
-    fn go_booting(&mut self);
+    /// Generate the initial validator set for the appchain.
+    fn generate_initial_validator_set(&mut self);
     /// Verify and change the state of corresponding appchain to `active`.
     fn go_live(&mut self);
     /// Initialize the beefy light client

--- a/appchain-anchor/src/lib.rs
+++ b/appchain-anchor/src/lib.rs
@@ -53,7 +53,7 @@ use validator_set::ValidatorSetViewer;
 register_custom_getrandom!(get_random_in_near);
 
 /// Version of this contract (the same as in Cargo.toml)
-const ANCHOR_VERSION: &str = "v2.3.1";
+const ANCHOR_VERSION: &str = "v2.4.0";
 /// Constants for gas.
 const T_GAS_FOR_FT_TRANSFER: u64 = 10;
 const T_GAS_FOR_BURN_FUNGIBLE_TOKEN: u64 = 10;
@@ -502,7 +502,7 @@ impl AppchainAnchor {
         let predecessor_account_id = env::predecessor_account_id();
         match deposit_message {
             FTDepositMessage::RegisterValidator { .. }
-            | FTDepositMessage::IncreaseStake
+            | FTDepositMessage::IncreaseStake { .. }
             | FTDepositMessage::RegisterDelegator { .. }
             | FTDepositMessage::IncreaseDelegation { .. } => {
                 assert!(

--- a/appchain-anchor/src/lib.rs
+++ b/appchain-anchor/src/lib.rs
@@ -265,7 +265,7 @@ impl AppchainAnchor {
                 StorageKey::ProtocolSettings.into_bytes(),
                 Some(&ProtocolSettings::default()),
             ),
-            appchain_state: AppchainState::Staging,
+            appchain_state: AppchainState::Booting,
             staking_histories: LazyOption::new(
                 StorageKey::StakingHistories.into_bytes(),
                 Some(&LookupArray::new(StorageKey::StakingHistoriesMap)),

--- a/appchain-anchor/src/permissionless_actions/switching_era.rs
+++ b/appchain-anchor/src/permissionless_actions/switching_era.rs
@@ -240,7 +240,15 @@ impl AppchainAnchor {
                 let args = near_sdk::serde_json::to_vec(&args)
                     .expect("Failed to serialize the cross contract args using JSON.");
                 let contract_account = AccountId::from_str(
-                    format!("council-keeper.{}", self.appchain_registry).as_str(),
+                    format!(
+                        "{}.{}",
+                        self.protocol_settings
+                            .get()
+                            .unwrap()
+                            .subaccount_for_council_keeper_contract,
+                        self.appchain_registry
+                    )
+                    .as_str(),
                 )
                 .unwrap();
                 Promise::new(contract_account).function_call(

--- a/appchain-anchor/src/permissionless_actions/switching_era.rs
+++ b/appchain-anchor/src/permissionless_actions/switching_era.rs
@@ -240,7 +240,7 @@ impl AppchainAnchor {
                 let args = near_sdk::serde_json::to_vec(&args)
                     .expect("Failed to serialize the cross contract args using JSON.");
                 let contract_account = AccountId::from_str(
-                    format!("octopus-council.{}", self.appchain_registry).as_str(),
+                    format!("council-keeper.{}", self.appchain_registry).as_str(),
                 )
                 .unwrap();
                 Promise::new(contract_account).function_call(

--- a/appchain-anchor/src/storage_migration.rs
+++ b/appchain-anchor/src/storage_migration.rs
@@ -66,6 +66,8 @@ pub struct OldAppchainAnchor {
     appchain_challenges: LazyOption<LookupArray<AppchainChallenge>>,
     /// The wrapped appchain NFT data
     wrapped_appchain_nfts: LazyOption<WrappedAppchainNFTs>,
+    /// The native NEAR token data
+    native_near_token: LazyOption<NativeNearToken>,
 }
 
 #[near_bindgen]
@@ -108,10 +110,7 @@ impl AppchainAnchor {
             appchain_messages: old_contract.appchain_messages,
             appchain_challenges: old_contract.appchain_challenges,
             wrapped_appchain_nfts: old_contract.wrapped_appchain_nfts,
-            native_near_token: LazyOption::new(
-                StorageKey::NativeNearToken.into_bytes(),
-                Some(&NativeNearToken::default()),
-            ),
+            native_near_token: old_contract.native_near_token,
         };
         //
         //

--- a/appchain-anchor/src/storage_migration.rs
+++ b/appchain-anchor/src/storage_migration.rs
@@ -31,6 +31,58 @@ pub enum OldAppchainState {
     Dead,
 }
 
+#[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Clone)]
+#[serde(crate = "near_sdk::serde")]
+pub struct OldProtocolSettings {
+    /// A validator has to deposit a certain amount of OCT token to this contract for
+    /// being validator of the appchain.
+    pub minimum_validator_deposit: U128,
+    /// The minimum amount for a validator to increase or decrease his/her deposit.
+    pub minimum_validator_deposit_changing_amount: U128,
+    /// The maximum percent value that the deposit of a validator in total stake
+    pub maximum_validator_stake_percent: u16,
+    /// The minimum deposit amount for a delegator to delegate his voting weight to
+    /// a certain validator.
+    pub minimum_delegator_deposit: U128,
+    /// The minimum amount for a delegator to increase or decrease his/her delegation
+    /// to a validator.
+    pub minimum_delegator_deposit_changing_amount: U128,
+    /// The minimum price (in USD) of total stake in this contract for
+    /// booting corresponding appchain
+    pub minimum_total_stake_price_for_booting: U128,
+    /// The maximum percentage of the total market value of all NEP-141 tokens to the total
+    /// market value of OCT token staked in this contract
+    pub maximum_market_value_percent_of_near_fungible_tokens: u16,
+    /// The maximum percentage of the total market value of wrapped appchain token to the total
+    /// market value of OCT token staked in this contract
+    pub maximum_market_value_percent_of_wrapped_appchain_token: u16,
+    /// The minimum number of validator(s) registered in this contract for
+    /// booting the corresponding appchain and keep it alive.
+    pub minimum_validator_count: U64,
+    /// The maximum number of validator(s) registered in this contract for
+    /// the corresponding appchain.
+    pub maximum_validator_count: U64,
+    /// The maximum number of validator(s) which a delegator can delegate to.
+    pub maximum_validators_per_delegator: U64,
+    /// The unlock period (in days) for validator(s) can withdraw their deposit after
+    /// they are removed from the corresponding appchain.
+    pub unlock_period_of_validator_deposit: U64,
+    /// The unlock period (in days) for delegator(s) can withdraw their deposit after
+    /// they no longer delegates their stake to a certain validator on the corresponding appchain.
+    pub unlock_period_of_delegator_deposit: U64,
+    /// The maximum number of historical eras that the validators or delegators are allowed to
+    /// withdraw their reward
+    pub maximum_era_count_of_unwithdrawn_reward: U64,
+    /// The maximum number of valid appchain message.
+    /// If the era number of appchain message is smaller than the latest era number minus
+    /// this value, the message will be considered as `invalid`.
+    pub maximum_era_count_of_valid_appchain_message: U64,
+    /// The percent of commission fees of a validator's reward in an era
+    pub validator_commission_percent: u16,
+    /// The maximum unprofitable era count for auto-unbonding a validator
+    pub maximum_allowed_unprofitable_era_count: u16,
+}
+
 #[derive(BorshDeserialize, BorshSerialize)]
 pub struct OldAppchainAnchor {
     /// The id of corresponding appchain.
@@ -69,7 +121,7 @@ pub struct OldAppchainAnchor {
     /// The anchor settings for appchain.
     anchor_settings: LazyOption<AnchorSettings>,
     /// The protocol settings for appchain anchor.
-    protocol_settings: LazyOption<ProtocolSettings>,
+    protocol_settings: LazyOption<OldProtocolSettings>,
     /// The state of the corresponding appchain.
     appchain_state: OldAppchainState,
     /// The staking history data happened in this contract.
@@ -125,7 +177,12 @@ impl AppchainAnchor {
             validator_profiles: old_contract.validator_profiles,
             appchain_settings: old_contract.appchain_settings,
             anchor_settings: old_contract.anchor_settings,
-            protocol_settings: old_contract.protocol_settings,
+            protocol_settings: LazyOption::new(
+                StorageKey::ProtocolSettings.into_bytes(),
+                Some(&ProtocolSettings::from_old_version(
+                    old_contract.protocol_settings.get().unwrap(),
+                )),
+            ),
             appchain_state: AppchainState::from_old_version(old_contract.appchain_state),
             staking_histories: old_contract.staking_histories,
             appchain_notification_histories: old_contract.appchain_notification_histories,
@@ -158,6 +215,39 @@ impl AppchainState {
             OldAppchainState::Frozen => AppchainState::Closing,
             OldAppchainState::Broken => AppchainState::Closing,
             OldAppchainState::Dead => AppchainState::Closed,
+        }
+    }
+}
+
+impl ProtocolSettings {
+    pub fn from_old_version(old_version: OldProtocolSettings) -> Self {
+        ProtocolSettings {
+            minimum_validator_deposit: old_version.minimum_validator_deposit,
+            minimum_validator_deposit_changing_amount: old_version
+                .minimum_validator_deposit_changing_amount,
+            maximum_validator_stake_percent: old_version.maximum_validator_stake_percent,
+            minimum_delegator_deposit: old_version.minimum_delegator_deposit,
+            minimum_delegator_deposit_changing_amount: old_version
+                .minimum_delegator_deposit_changing_amount,
+            minimum_total_stake_price_for_booting: old_version
+                .minimum_total_stake_price_for_booting,
+            maximum_market_value_percent_of_near_fungible_tokens: old_version
+                .maximum_market_value_percent_of_near_fungible_tokens,
+            maximum_market_value_percent_of_wrapped_appchain_token: old_version
+                .maximum_market_value_percent_of_wrapped_appchain_token,
+            minimum_validator_count: old_version.minimum_validator_count,
+            maximum_validator_count: old_version.maximum_validator_count,
+            maximum_validators_per_delegator: old_version.maximum_validators_per_delegator,
+            unlock_period_of_validator_deposit: old_version.unlock_period_of_validator_deposit,
+            unlock_period_of_delegator_deposit: old_version.unlock_period_of_delegator_deposit,
+            maximum_era_count_of_unwithdrawn_reward: old_version
+                .maximum_era_count_of_unwithdrawn_reward,
+            maximum_era_count_of_valid_appchain_message: old_version
+                .maximum_era_count_of_valid_appchain_message,
+            validator_commission_percent: old_version.validator_commission_percent,
+            maximum_allowed_unprofitable_era_count: old_version
+                .maximum_allowed_unprofitable_era_count,
+            subaccount_for_council_keeper_contract: "octopus-council".to_string(),
         }
     }
 }

--- a/appchain-anchor/src/types.rs
+++ b/appchain-anchor/src/types.rs
@@ -82,24 +82,18 @@ pub enum AppchainState {
     Registered,
     /// The state while the appchain is under auditing by Octopus Network.
     /// This state is managed by appchain registry.
-    Auditing,
-    /// The state while voter can upvote or downvote an appchain.
+    Audited,
+    /// The state while members of Octopus DAO can upvote for the appchain.
     /// This state is managed by appchain registry.
-    InQueue,
-    /// The state while validator and delegator can deposit OCT tokens to this contract
-    /// to indicate their willing of staking for an appchain.
-    Staging,
+    Voting,
     /// The state while an appchain is booting.
     Booting,
     /// The state while an appchain is active normally.
     Active,
-    /// The state while an appchain is under challenging, which all deposit and withdraw actions
-    /// are frozen.
-    Frozen,
-    /// The state which an appchain is broken for some technical or governance reasons.
-    Broken,
+    /// The state which an appchain is closing for some technical or governance reasons.
+    Closing,
     /// The state which the lifecycle of an appchain is end.
-    Dead,
+    Closed,
 }
 
 #[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Clone)]

--- a/appchain-anchor/src/types.rs
+++ b/appchain-anchor/src/types.rs
@@ -121,7 +121,7 @@ pub struct ProtocolSettings {
     pub minimum_validator_deposit: U128,
     /// The minimum amount for a validator to increase or decrease his/her deposit.
     pub minimum_validator_deposit_changing_amount: U128,
-    /// The maximum percent value that the deposit of a validator in total stake
+    /// The maximum percent value that the deposit of a validator in total stake.
     pub maximum_validator_stake_percent: u16,
     /// The minimum deposit amount for a delegator to delegate his voting weight to
     /// a certain validator.
@@ -130,13 +130,13 @@ pub struct ProtocolSettings {
     /// to a validator.
     pub minimum_delegator_deposit_changing_amount: U128,
     /// The minimum price (in USD) of total stake in this contract for
-    /// booting corresponding appchain
+    /// booting corresponding appchain.
     pub minimum_total_stake_price_for_booting: U128,
     /// The maximum percentage of the total market value of all NEP-141 tokens to the total
-    /// market value of OCT token staked in this contract
+    /// market value of OCT token staked in this contract.
     pub maximum_market_value_percent_of_near_fungible_tokens: u16,
     /// The maximum percentage of the total market value of wrapped appchain token to the total
-    /// market value of OCT token staked in this contract
+    /// market value of OCT token staked in this contract.
     pub maximum_market_value_percent_of_wrapped_appchain_token: u16,
     /// The minimum number of validator(s) registered in this contract for
     /// booting the corresponding appchain and keep it alive.
@@ -153,16 +153,18 @@ pub struct ProtocolSettings {
     /// they no longer delegates their stake to a certain validator on the corresponding appchain.
     pub unlock_period_of_delegator_deposit: U64,
     /// The maximum number of historical eras that the validators or delegators are allowed to
-    /// withdraw their reward
+    /// withdraw their reward.
     pub maximum_era_count_of_unwithdrawn_reward: U64,
     /// The maximum number of valid appchain message.
     /// If the era number of appchain message is smaller than the latest era number minus
     /// this value, the message will be considered as `invalid`.
     pub maximum_era_count_of_valid_appchain_message: U64,
-    /// The percent of commission fees of a validator's reward in an era
+    /// The percent of commission fees of a validator's reward in an era.
     pub validator_commission_percent: u16,
-    /// The maximum unprofitable era count for auto-unbonding a validator
+    /// The maximum unprofitable era count for auto-unbonding a validator.
     pub maximum_allowed_unprofitable_era_count: u16,
+    /// The subaccount name for council keeper contract.
+    pub subaccount_for_council_keeper_contract: String,
 }
 
 #[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Clone)]

--- a/appchain-anchor/src/types.rs
+++ b/appchain-anchor/src/types.rs
@@ -656,12 +656,16 @@ pub enum FTDepositMessage {
         can_be_delegated_to: bool,
         profile: HashMap<String, String>,
     },
-    IncreaseStake,
+    IncreaseStake {
+        validator_id: Option<AccountId>,
+    },
     RegisterDelegator {
         validator_id: AccountId,
+        delegator_id: Option<AccountId>,
     },
     IncreaseDelegation {
         validator_id: AccountId,
+        delegator_id: Option<AccountId>,
     },
     BridgeToAppchain {
         receiver_id_in_appchain: String,

--- a/appchain-anchor/src/user_actions/appchain_lifecycle.rs
+++ b/appchain-anchor/src/user_actions/appchain_lifecycle.rs
@@ -6,12 +6,12 @@ use crate::{
 #[near_bindgen]
 impl AppchainLifecycleManager for AppchainAnchor {
     //
-    fn go_booting(&mut self) {
+    fn generate_initial_validator_set(&mut self) {
         self.assert_owner();
         assert_eq!(
             self.appchain_state,
-            AppchainState::Staging,
-            "Appchain state must be 'staging'."
+            AppchainState::Booting,
+            "Appchain state must be 'Booting'."
         );
         let protocol_settings = self.protocol_settings.get().unwrap();
         let next_validator_set = self.next_validator_set.get().unwrap();
@@ -25,7 +25,6 @@ impl AppchainLifecycleManager for AppchainAnchor {
                 >= protocol_settings.minimum_total_stake_price_for_booting.0,
             "Not enough stake deposited in anchor."
         );
-        self.appchain_state = AppchainState::Booting;
         let mut processing_context = AppchainMessagesProcessingContext::new(
             self.permissionless_actions_status.get().unwrap(),
         );
@@ -54,6 +53,11 @@ impl AppchainLifecycleManager for AppchainAnchor {
             self.appchain_state,
             AppchainState::Booting,
             "Appchain state must be 'booting'."
+        );
+        let validator_set_histories = self.validator_set_histories.get().unwrap();
+        assert!(
+            validator_set_histories.get(&0).is_some(),
+            "The validator set 0 has not been generated."
         );
         let wrapped_appchain_token = self.wrapped_appchain_token.get().unwrap();
         assert!(

--- a/appchain-anchor/src/user_actions/settings_manager.rs
+++ b/appchain-anchor/src/user_actions/settings_manager.rs
@@ -24,6 +24,7 @@ impl Default for ProtocolSettings {
             maximum_era_count_of_valid_appchain_message: U64::from(7),
             validator_commission_percent: 20,
             maximum_allowed_unprofitable_era_count: 3,
+            subaccount_for_council_keeper_contract: "octopus-council".to_string(),
         }
     }
 }
@@ -281,6 +282,21 @@ impl ProtocolSettingsManager for AppchainAnchor {
             "The value is not changed."
         );
         protocol_settings.maximum_allowed_unprofitable_era_count = value;
+        self.protocol_settings.set(&protocol_settings);
+    }
+    //
+    fn change_subaccount_for_council_keeper_contract(&mut self, subaccount_name: String) {
+        self.assert_owner();
+        assert!(
+            !subaccount_name.trim().is_empty(),
+            "The subaccount name can not be empty."
+        );
+        let mut protocol_settings = self.protocol_settings.get().unwrap();
+        assert!(
+            !subaccount_name.eq(&protocol_settings.subaccount_for_council_keeper_contract),
+            "The value is not changed."
+        );
+        protocol_settings.subaccount_for_council_keeper_contract = subaccount_name;
         self.protocol_settings.set(&protocol_settings);
     }
 }

--- a/appchain-anchor/src/user_actions/staking.rs
+++ b/appchain-anchor/src/user_actions/staking.rs
@@ -62,7 +62,7 @@ impl AppchainAnchor {
         can_be_delegated_to: bool,
     ) {
         match self.appchain_state {
-            AppchainState::Staging | AppchainState::Active => (),
+            AppchainState::Booting | AppchainState::Active => (),
             _ => panic!(
                 "Cannot register validator while appchain state is '{}'.",
                 serde_json::to_string(&self.appchain_state).unwrap()
@@ -166,7 +166,7 @@ impl AppchainAnchor {
     //
     fn increase_stake(&mut self, validator_id: AccountId, amount: U128) {
         match self.appchain_state {
-            AppchainState::Staging | AppchainState::Active => (),
+            AppchainState::Booting | AppchainState::Active => (),
             _ => panic!(
                 "Cannot increase stake while appchain state is '{}'.",
                 serde_json::to_string(&self.appchain_state).unwrap()
@@ -209,7 +209,7 @@ impl AppchainAnchor {
         deposit_amount: U128,
     ) {
         match self.appchain_state {
-            AppchainState::Staging | AppchainState::Active => (),
+            AppchainState::Booting | AppchainState::Active => (),
             _ => panic!(
                 "Cannot register delegator while appchain state is '{}'.",
                 serde_json::to_string(&self.appchain_state).unwrap()
@@ -284,7 +284,7 @@ impl AppchainAnchor {
         amount: U128,
     ) {
         match self.appchain_state {
-            AppchainState::Staging | AppchainState::Active => (),
+            AppchainState::Booting | AppchainState::Active => (),
             _ => panic!(
                 "Cannot increase delegation while appchain state is '{}'.",
                 serde_json::to_string(&self.appchain_state).unwrap()
@@ -327,7 +327,7 @@ impl StakingManager for AppchainAnchor {
     //
     fn decrease_stake(&mut self, amount: U128) {
         match self.appchain_state {
-            AppchainState::Active => (),
+            AppchainState::Booting | AppchainState::Active => (),
             _ => panic!(
                 "Cannot decrease stake while appchain state is '{}'.",
                 serde_json::to_string(&self.appchain_state).unwrap()
@@ -368,7 +368,7 @@ impl StakingManager for AppchainAnchor {
     //
     fn unbond_stake(&mut self) {
         match self.appchain_state {
-            AppchainState::Active | AppchainState::Broken => (),
+            AppchainState::Active | AppchainState::Closing => (),
             _ => panic!(
                 "Cannot unbond stake while appchain state is '{}'.",
                 serde_json::to_string(&self.appchain_state).unwrap()
@@ -419,7 +419,7 @@ impl StakingManager for AppchainAnchor {
     //
     fn decrease_delegation(&mut self, validator_id: AccountId, amount: U128) {
         match self.appchain_state {
-            AppchainState::Active => (),
+            AppchainState::Booting | AppchainState::Active => (),
             _ => panic!(
                 "Cannot decrease delegation while appchain state is '{}'.",
                 serde_json::to_string(&self.appchain_state).unwrap()
@@ -464,7 +464,7 @@ impl StakingManager for AppchainAnchor {
     //
     fn unbond_delegation(&mut self, validator_id: AccountId) {
         match self.appchain_state {
-            AppchainState::Active | AppchainState::Broken => (),
+            AppchainState::Active | AppchainState::Closing => (),
             _ => panic!(
                 "Cannot unbond delegation while appchain state is '{}'.",
                 serde_json::to_string(&self.appchain_state).unwrap()
@@ -690,7 +690,7 @@ impl StakingManager for AppchainAnchor {
         new_validator_id: AccountId,
     ) {
         match self.appchain_state {
-            AppchainState::Active | AppchainState::Broken => (),
+            AppchainState::Active => (),
             _ => panic!(
                 "Cannot change delegated validator while appchain state is '{}'.",
                 serde_json::to_string(&self.appchain_state).unwrap()

--- a/appchain-anchor/src/user_actions/staking.rs
+++ b/appchain-anchor/src/user_actions/staking.rs
@@ -29,16 +29,22 @@ impl AppchainAnchor {
                 );
                 PromiseOrValue::Value(0.into())
             }
-            FTDepositMessage::IncreaseStake => {
-                self.increase_stake(sender_id, amount);
+            FTDepositMessage::IncreaseStake { validator_id } => {
+                self.increase_stake(validator_id.unwrap_or(sender_id), amount);
                 PromiseOrValue::Value(0.into())
             }
-            FTDepositMessage::RegisterDelegator { validator_id } => {
-                self.register_delegator(sender_id, validator_id, amount);
+            FTDepositMessage::RegisterDelegator {
+                validator_id,
+                delegator_id,
+            } => {
+                self.register_delegator(delegator_id.unwrap_or(sender_id), validator_id, amount);
                 PromiseOrValue::Value(0.into())
             }
-            FTDepositMessage::IncreaseDelegation { validator_id } => {
-                self.increase_delegation(sender_id, validator_id, amount);
+            FTDepositMessage::IncreaseDelegation {
+                validator_id,
+                delegator_id,
+            } => {
+                self.increase_delegation(delegator_id.unwrap_or(sender_id), validator_id, amount);
                 PromiseOrValue::Value(0.into())
             }
             _ => panic!(

--- a/e2e-tests/anchor-methods.js
+++ b/e2e-tests/anchor-methods.js
@@ -25,7 +25,7 @@ module.exports = {
     // oct price
     'set_price_of_oct_token',
     // appchain lifecycle
-    'go_booting',
+    'generate_initial_validator_set',
     'go_live',
     // staking & delegating
     'decrease_stake',

--- a/e2e-tests/main.test.js
+++ b/e2e-tests/main.test.js
@@ -272,7 +272,7 @@ test('test increase stake', async () => {
 });
 
 test('test go booting', async () => {
-  await anchor.go_booting({}, CALL_GAS, 0);
+  await anchor.generate_initial_validator_set({}, CALL_GAS, 0);
   const appchainState = await anchor.get_appchain_state();
   expect(appchainState).toEqual('Booting');
 });

--- a/tests/simulator/common/basic_actions.rs
+++ b/tests/simulator/common/basic_actions.rs
@@ -85,7 +85,7 @@ pub async fn initialize_contracts_and_users(
     //
     let council_keeper = appchain_registry
         .as_account()
-        .create_subaccount(worker, "council-keeper")
+        .create_subaccount(worker, "octopus-council")
         .initial_balance(parse_near!("10 N"))
         .transact()
         .await?
@@ -117,7 +117,7 @@ pub async fn initialize_contracts_and_users(
         true => appchain_anchor
             .deploy(
                 worker,
-                &std::fs::read(format!("res/appchain_anchor_v2.3.0.wasm"))?,
+                &std::fs::read(format!("res/appchain_anchor_v2.3.1.wasm"))?,
             )
             .await?
             .unwrap(),

--- a/tests/simulator/common/basic_actions.rs
+++ b/tests/simulator/common/basic_actions.rs
@@ -83,21 +83,22 @@ pub async fn initialize_contracts_and_users(
     //
     // deploy octopus council contract
     //
-    let octopus_council = appchain_registry
+    let council_keeper = appchain_registry
         .as_account()
-        .create_subaccount(worker, "octopus-council")
+        .create_subaccount(worker, "council-keeper")
         .initial_balance(parse_near!("10 N"))
         .transact()
         .await?
         .unwrap();
-    let octopus_council = octopus_council
-        .deploy(worker, &std::fs::read(format!("res/octopus_council.wasm"))?)
+    let council_keeper = council_keeper
+        .deploy(worker, &std::fs::read(format!("res/council_keeper.wasm"))?)
         .await?
         .unwrap();
-    octopus_council
+    council_keeper
         .call(worker, "new")
         .args_json(json!({
-            "max_number_of_council_members": 3
+            "max_number_of_council_members": 3,
+            "dao_contract_account": council_keeper.id().to_string(),
         }))?
         .gas(300_000_000_000_000)
         .transact()
@@ -116,7 +117,7 @@ pub async fn initialize_contracts_and_users(
         true => appchain_anchor
             .deploy(
                 worker,
-                &std::fs::read(format!("res/appchain_anchor_v2.2.0.wasm"))?,
+                &std::fs::read(format!("res/appchain_anchor_v2.3.0.wasm"))?,
             )
             .await?
             .unwrap(),
@@ -239,7 +240,7 @@ pub async fn initialize_contracts_and_users(
         root,
         oct_token,
         appchain_registry,
-        octopus_council,
+        council_keeper,
         appchain_anchor,
         wat_faucet,
         users,

--- a/tests/simulator/common/mod.rs
+++ b/tests/simulator/common/mod.rs
@@ -119,7 +119,7 @@ pub async fn test_normal_actions(
     //
     assert_eq!(
         anchor_viewer::get_appchain_state(worker, &anchor).await?,
-        AppchainState::Staging
+        AppchainState::Booting
     );
     if to_confirm_view_result {
         let anchor_status = anchor_viewer::get_anchor_status(worker, &anchor).await?;
@@ -464,13 +464,13 @@ pub async fn test_normal_actions(
         complex_viewer::print_validator_list_of(worker, &anchor, None).await?;
     }
     //
-    // Try go_booting
+    // Try generate_initial_validator_set
     //
-    lifecycle_actions::go_booting(worker, &root, &anchor)
+    lifecycle_actions::generate_initial_validator_set(worker, &root, &anchor)
         .await
         .expect_err("Should fail");
     //
-    // Set appchain settings and try go_booting
+    // Set appchain settings and try generate_initial_validator_set
     //
     settings_manager::set_rpc_endpoint(worker, &root, &anchor, "rpc_endpoint".to_string())
         .await
@@ -481,27 +481,27 @@ pub async fn test_normal_actions(
     settings_manager::set_era_reward(worker, &root, &anchor, to_actual_amount(10, 18))
         .await
         .expect("Failed in calling 'set_era_reward'");
-    lifecycle_actions::go_booting(worker, &root, &anchor)
+    lifecycle_actions::generate_initial_validator_set(worker, &root, &anchor)
         .await
         .expect_err("Should fail");
     //
-    // Change protocol settings and try go_booting
+    // Change protocol settings and try generate_initial_validator_set
     //
     settings_manager::change_minimum_validator_count(worker, &root, &anchor, 1)
         .await
         .expect("Failed in calling 'change_minimum_validator_count'");
-    lifecycle_actions::go_booting(worker, &root, &anchor)
+    lifecycle_actions::generate_initial_validator_set(worker, &root, &anchor)
         .await
         .expect_err("Should fail");
     //
-    // Change price of OCT token and try go_booting
+    // Change price of OCT token and try generate_initial_validator_set
     //
     settings_manager::set_price_of_oct_token(worker, &users[4], &anchor, 2_130_000)
         .await
         .expect("Failed in calling 'set_price_of_oct_token'");
-    lifecycle_actions::go_booting(worker, &root, &anchor)
+    lifecycle_actions::generate_initial_validator_set(worker, &root, &anchor)
         .await
-        .expect("Failed in calling 'go_booting'");
+        .expect("Failed in calling 'generate_initial_validator_set'");
     assert_eq!(
         anchor_viewer::get_appchain_state(worker, &anchor).await?,
         AppchainState::Booting

--- a/tests/simulator/contract_interfaces/lifecycle_actions.rs
+++ b/tests/simulator/contract_interfaces/lifecycle_actions.rs
@@ -1,13 +1,13 @@
 use near_sdk::serde_json::json;
 use workspaces::{network::Sandbox, result::CallExecutionDetails, Account, Contract, Worker};
 
-pub async fn go_booting(
+pub async fn generate_initial_validator_set(
     worker: &Worker<Sandbox>,
     signer: &Account,
     anchor: &Contract,
 ) -> anyhow::Result<CallExecutionDetails> {
     signer
-        .call(worker, anchor.id(), "go_booting")
+        .call(worker, anchor.id(), "generate_initial_validator_set")
         .gas(200_000_000_000_000)
         .transact()
         .await

--- a/tests/simulator/contract_interfaces/staking_actions.rs
+++ b/tests/simulator/contract_interfaces/staking_actions.rs
@@ -49,7 +49,8 @@ pub async fn register_delegator(
         amount,
         json!({
             "RegisterDelegator": {
-                "validator_id": validator_id
+                "validator_id": validator_id,
+                "delegator_id": null,
             }
         })
         .to_string(),
@@ -70,7 +71,12 @@ pub async fn increase_stake(
         signer,
         &anchor.as_account(),
         amount,
-        "\"IncreaseStake\"".to_string(),
+        json!({
+            "IncreaseStake": {
+                "validator_id": null,
+            }
+        })
+        .to_string(),
         oct_token,
     )
     .await
@@ -91,7 +97,8 @@ pub async fn increase_delegation(
         amount,
         json!({
             "IncreaseDelegation": {
-                "validator_id": validator_id
+                "validator_id": validator_id,
+                "delegator_id": null,
             }
         })
         .to_string(),

--- a/tests/simulator/test_sync_staking_amount.rs
+++ b/tests/simulator/test_sync_staking_amount.rs
@@ -1,9 +1,9 @@
 use crate::common::{self, complex_actions};
+use council_keeper::types::{CouncilChangeHistory, ValidatorStake};
 use near_sdk::{
     serde_json::{self, json},
     AccountId,
 };
-use octopus_council::types::{CouncilChangeHistory, ValidatorStake};
 
 #[tokio::test]
 async fn test_sync_staking_amount() -> anyhow::Result<()> {
@@ -14,7 +14,7 @@ async fn test_sync_staking_amount() -> anyhow::Result<()> {
         _,
         wrapped_appchain_token,
         _registry,
-        council,
+        council_keeper,
         anchor,
         _wat_faucet,
         users,
@@ -67,7 +67,7 @@ async fn test_sync_staking_amount() -> anyhow::Result<()> {
     //
     //
     //
-    let result = council
+    let result = council_keeper
         .call(&worker, "get_living_appchain_ids")
         .view()
         .await?
@@ -78,7 +78,7 @@ async fn test_sync_staking_amount() -> anyhow::Result<()> {
         serde_json::to_string::<Vec<String>>(&result).unwrap()
     );
     //
-    let result = council
+    let result = council_keeper
         .call(&worker, "get_council_members")
         .view()
         .await?
@@ -89,7 +89,7 @@ async fn test_sync_staking_amount() -> anyhow::Result<()> {
         serde_json::to_string::<Vec<AccountId>>(&result).unwrap()
     );
     //
-    let result = council
+    let result = council_keeper
         .call(&worker, "get_ranked_validator_stakes")
         .args_json(json!( {
             "start_index": 0,
@@ -104,7 +104,7 @@ async fn test_sync_staking_amount() -> anyhow::Result<()> {
         serde_json::to_string::<Vec<ValidatorStake>>(&result).unwrap()
     );
     //
-    let result = council
+    let result = council_keeper
         .call(&worker, "get_council_change_histories")
         .args_json(json!( {
             "start_index": "0",


### PR DESCRIPTION
## All changes

* Change design of `FTDepositMessage` to support the following use cases:
  * `IncreaseStake` for a given validator
  * `RegisterDelegator` for a given account 
  * `IncreaseDelegation` for a given delegator.
* Redefine `AppchainState`. Refer to [Octopus Registry contract pr#18](https://github.com/octopus-network/octopus-appchain-registry/pull/18).
* Add protocol settings `subaccount_for_council_keeper_contract`, rather than hard code this name.
