### PR TITLE
Upgrade to v2.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "appchain-anchor-wrapper"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "anyhow",
  "appchain-anchor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "appchain-anchor-wrapper"
-version = "2.4.0"
+version = "2.4.1"
 authors = ["Octopus Network"]
 edition = "2021"
 

--- a/appchain-anchor/src/lib.rs
+++ b/appchain-anchor/src/lib.rs
@@ -53,7 +53,7 @@ use validator_set::ValidatorSetViewer;
 register_custom_getrandom!(get_random_in_near);
 
 /// Version of this contract (the same as in Cargo.toml)
-const ANCHOR_VERSION: &str = "v2.4.0";
+const ANCHOR_VERSION: &str = "v2.4.1";
 /// Constants for gas.
 const T_GAS_FOR_FT_TRANSFER: u64 = 10;
 const T_GAS_FOR_BURN_FUNGIBLE_TOKEN: u64 = 10;

--- a/appchain-anchor/src/storage_migration.rs
+++ b/appchain-anchor/src/storage_migration.rs
@@ -3,86 +3,6 @@ use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 use near_sdk::collections::{LazyOption, LookupMap};
 use near_sdk::{env, near_bindgen, AccountId, Balance};
 
-#[derive(Clone, Serialize, Deserialize, BorshDeserialize, BorshSerialize, Debug, PartialEq)]
-#[serde(crate = "near_sdk::serde")]
-pub enum OldAppchainState {
-    /// The initial state of an appchain, after it is successfully registered.
-    /// This state is managed by appchain registry.
-    Registered,
-    /// The state while the appchain is under auditing by Octopus Network.
-    /// This state is managed by appchain registry.
-    Auditing,
-    /// The state while voter can upvote or downvote an appchain.
-    /// This state is managed by appchain registry.
-    InQueue,
-    /// The state while validator and delegator can deposit OCT tokens to this contract
-    /// to indicate their willing of staking for an appchain.
-    Staging,
-    /// The state while an appchain is booting.
-    Booting,
-    /// The state while an appchain is active normally.
-    Active,
-    /// The state while an appchain is under challenging, which all deposit and withdraw actions
-    /// are frozen.
-    Frozen,
-    /// The state which an appchain is broken for some technical or governance reasons.
-    Broken,
-    /// The state which the lifecycle of an appchain is end.
-    Dead,
-}
-
-#[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Clone)]
-#[serde(crate = "near_sdk::serde")]
-pub struct OldProtocolSettings {
-    /// A validator has to deposit a certain amount of OCT token to this contract for
-    /// being validator of the appchain.
-    pub minimum_validator_deposit: U128,
-    /// The minimum amount for a validator to increase or decrease his/her deposit.
-    pub minimum_validator_deposit_changing_amount: U128,
-    /// The maximum percent value that the deposit of a validator in total stake
-    pub maximum_validator_stake_percent: u16,
-    /// The minimum deposit amount for a delegator to delegate his voting weight to
-    /// a certain validator.
-    pub minimum_delegator_deposit: U128,
-    /// The minimum amount for a delegator to increase or decrease his/her delegation
-    /// to a validator.
-    pub minimum_delegator_deposit_changing_amount: U128,
-    /// The minimum price (in USD) of total stake in this contract for
-    /// booting corresponding appchain
-    pub minimum_total_stake_price_for_booting: U128,
-    /// The maximum percentage of the total market value of all NEP-141 tokens to the total
-    /// market value of OCT token staked in this contract
-    pub maximum_market_value_percent_of_near_fungible_tokens: u16,
-    /// The maximum percentage of the total market value of wrapped appchain token to the total
-    /// market value of OCT token staked in this contract
-    pub maximum_market_value_percent_of_wrapped_appchain_token: u16,
-    /// The minimum number of validator(s) registered in this contract for
-    /// booting the corresponding appchain and keep it alive.
-    pub minimum_validator_count: U64,
-    /// The maximum number of validator(s) registered in this contract for
-    /// the corresponding appchain.
-    pub maximum_validator_count: U64,
-    /// The maximum number of validator(s) which a delegator can delegate to.
-    pub maximum_validators_per_delegator: U64,
-    /// The unlock period (in days) for validator(s) can withdraw their deposit after
-    /// they are removed from the corresponding appchain.
-    pub unlock_period_of_validator_deposit: U64,
-    /// The unlock period (in days) for delegator(s) can withdraw their deposit after
-    /// they no longer delegates their stake to a certain validator on the corresponding appchain.
-    pub unlock_period_of_delegator_deposit: U64,
-    /// The maximum number of historical eras that the validators or delegators are allowed to
-    /// withdraw their reward
-    pub maximum_era_count_of_unwithdrawn_reward: U64,
-    /// The maximum number of valid appchain message.
-    /// If the era number of appchain message is smaller than the latest era number minus
-    /// this value, the message will be considered as `invalid`.
-    pub maximum_era_count_of_valid_appchain_message: U64,
-    /// The percent of commission fees of a validator's reward in an era
-    pub validator_commission_percent: u16,
-    /// The maximum unprofitable era count for auto-unbonding a validator
-    pub maximum_allowed_unprofitable_era_count: u16,
-}
-
 #[derive(BorshDeserialize, BorshSerialize)]
 pub struct OldAppchainAnchor {
     /// The id of corresponding appchain.
@@ -121,9 +41,9 @@ pub struct OldAppchainAnchor {
     /// The anchor settings for appchain.
     anchor_settings: LazyOption<AnchorSettings>,
     /// The protocol settings for appchain anchor.
-    protocol_settings: LazyOption<OldProtocolSettings>,
+    protocol_settings: LazyOption<ProtocolSettings>,
     /// The state of the corresponding appchain.
-    appchain_state: OldAppchainState,
+    appchain_state: AppchainState,
     /// The staking history data happened in this contract.
     staking_histories: LazyOption<LookupArray<StakingHistory>>,
     /// The appchain notification history data.
@@ -177,13 +97,8 @@ impl AppchainAnchor {
             validator_profiles: old_contract.validator_profiles,
             appchain_settings: old_contract.appchain_settings,
             anchor_settings: old_contract.anchor_settings,
-            protocol_settings: LazyOption::new(
-                StorageKey::ProtocolSettings.into_bytes(),
-                Some(&ProtocolSettings::from_old_version(
-                    old_contract.protocol_settings.get().unwrap(),
-                )),
-            ),
-            appchain_state: AppchainState::from_old_version(old_contract.appchain_state),
+            protocol_settings: old_contract.protocol_settings,
+            appchain_state: old_contract.appchain_state,
             staking_histories: old_contract.staking_histories,
             appchain_notification_histories: old_contract.appchain_notification_histories,
             permissionless_actions_status: old_contract.permissionless_actions_status,
@@ -200,54 +115,5 @@ impl AppchainAnchor {
         //
         //
         new_contract
-    }
-}
-
-impl AppchainState {
-    pub fn from_old_version(old_version: OldAppchainState) -> Self {
-        match old_version {
-            OldAppchainState::Registered => AppchainState::Registered,
-            OldAppchainState::Auditing => AppchainState::Audited,
-            OldAppchainState::InQueue => AppchainState::Voting,
-            OldAppchainState::Staging => AppchainState::Booting,
-            OldAppchainState::Booting => AppchainState::Booting,
-            OldAppchainState::Active => AppchainState::Active,
-            OldAppchainState::Frozen => AppchainState::Closing,
-            OldAppchainState::Broken => AppchainState::Closing,
-            OldAppchainState::Dead => AppchainState::Closed,
-        }
-    }
-}
-
-impl ProtocolSettings {
-    pub fn from_old_version(old_version: OldProtocolSettings) -> Self {
-        ProtocolSettings {
-            minimum_validator_deposit: old_version.minimum_validator_deposit,
-            minimum_validator_deposit_changing_amount: old_version
-                .minimum_validator_deposit_changing_amount,
-            maximum_validator_stake_percent: old_version.maximum_validator_stake_percent,
-            minimum_delegator_deposit: old_version.minimum_delegator_deposit,
-            minimum_delegator_deposit_changing_amount: old_version
-                .minimum_delegator_deposit_changing_amount,
-            minimum_total_stake_price_for_booting: old_version
-                .minimum_total_stake_price_for_booting,
-            maximum_market_value_percent_of_near_fungible_tokens: old_version
-                .maximum_market_value_percent_of_near_fungible_tokens,
-            maximum_market_value_percent_of_wrapped_appchain_token: old_version
-                .maximum_market_value_percent_of_wrapped_appchain_token,
-            minimum_validator_count: old_version.minimum_validator_count,
-            maximum_validator_count: old_version.maximum_validator_count,
-            maximum_validators_per_delegator: old_version.maximum_validators_per_delegator,
-            unlock_period_of_validator_deposit: old_version.unlock_period_of_validator_deposit,
-            unlock_period_of_delegator_deposit: old_version.unlock_period_of_delegator_deposit,
-            maximum_era_count_of_unwithdrawn_reward: old_version
-                .maximum_era_count_of_unwithdrawn_reward,
-            maximum_era_count_of_valid_appchain_message: old_version
-                .maximum_era_count_of_valid_appchain_message,
-            validator_commission_percent: old_version.validator_commission_percent,
-            maximum_allowed_unprofitable_era_count: old_version
-                .maximum_allowed_unprofitable_era_count,
-            subaccount_for_council_keeper_contract: "octopus-council".to_string(),
-        }
     }
 }

--- a/appchain-anchor/src/user_actions/settings_manager.rs
+++ b/appchain-anchor/src/user_actions/settings_manager.rs
@@ -54,7 +54,7 @@ impl Default for AppchainSettings {
 impl ProtocolSettingsManager for AppchainAnchor {
     //
     fn change_minimum_validator_deposit(&mut self, value: U128) {
-        self.assert_owner();
+        self.assert_registry();
         let mut protocol_settings = self.protocol_settings.get().unwrap();
         assert!(
             value.0 != protocol_settings.minimum_validator_deposit.0,

--- a/tests/simulator/common/basic_actions.rs
+++ b/tests/simulator/common/basic_actions.rs
@@ -117,7 +117,7 @@ pub async fn initialize_contracts_and_users(
         true => appchain_anchor
             .deploy(
                 worker,
-                &std::fs::read(format!("res/appchain_anchor_v2.3.1.wasm"))?,
+                &std::fs::read(format!("res/appchain_anchor_v2.4.0.wasm"))?,
             )
             .await?
             .unwrap(),
@@ -142,9 +142,7 @@ pub async fn initialize_contracts_and_users(
         false => {
             root.call(worker, appchain_anchor.id(), "new")
                 .args_json(json!({
-                    "appchain_id": TEST_APPCHAIN_ID.to_string(),
                     "appchain_template_type": AppchainTemplateType::Barnacle,
-                    "appchain_registry": appchain_registry.id(),
                     "oct_token": oct_token.id(),
                 }))?
                 .gas(300_000_000_000_000)


### PR DESCRIPTION
## All Changes

* Change authority of function `change_minimum_validator_deposit`. This function can only be called by Octopus Appchain Registry contract now.
* Optimize implementation of function `new`. Now, the values of fields `appchain_id` and `appchain_registry` are set automatically.
