### PR TITLE
A small change matches the signature of beefy-light-client-on-icp

### DIFF
--- a/appchain-anchor/src/permissionless_actions/mod.rs
+++ b/appchain-anchor/src/permissionless_actions/mod.rs
@@ -147,7 +147,7 @@ impl PermissionlessActions for AppchainAnchor {
             // Check the signature
             let signature =
                 verification_proxy_signature.expect("Missing signature of verification proxy.");
-            let signature = secp256k1::ecdsa::Signature::from_der(&signature)
+            let signature = secp256k1::ecdsa::Signature::from_compact(&signature)
                 .expect("Invalid ecdsa signature.");
             let anchor_settings = self.anchor_settings.get().unwrap();
             let secp = secp256k1::Secp256k1::new();

--- a/appchain-anchor/src/user_actions/settings_manager.rs
+++ b/appchain-anchor/src/user_actions/settings_manager.rs
@@ -361,7 +361,7 @@ impl AnchorSettingsManager for AppchainAnchor {
     //
     fn set_verification_proxy_pubkey(&mut self, pubkey: Vec<u8>) {
         self.assert_owner();
-        assert!(pubkey.len() == 32, "Invalid length of pubkey.");
+        assert!(pubkey.len() == 33, "Invalid length of pubkey.");
         let mut anchor_settings = self.anchor_settings.get().unwrap();
         anchor_settings.verification_proxy_pubkey = Some(pubkey);
         self.anchor_settings.set(&anchor_settings);


### PR DESCRIPTION
Because the public key returned in the icp canister is in the compressed public key encoding format(33 bytes), so I made some minor changes.